### PR TITLE
add correct AWS API Gateway url in queries

### DIFF
--- a/packages/app/src/constants/apiPaths.ts
+++ b/packages/app/src/constants/apiPaths.ts
@@ -2,7 +2,7 @@ const API_PATHS = {
   product: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
   import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: "https://i6ok5isnzd.execute-api.eu-central-1.amazonaws.com/prod/",
   cart: "https://.execute-api.eu-west-1.amazonaws.com/dev",
 };
 

--- a/packages/app/src/queries/products.ts
+++ b/packages/app/src/queries/products.ts
@@ -9,7 +9,7 @@ export function useAvailableProducts() {
     "available-products",
     async () => {
       const res = await axios.get<AvailableProduct[]>(
-        `${API_PATHS.bff}/product/available`
+        `${API_PATHS.bff}/products`
       );
       return res.data;
     }


### PR DESCRIPTION
Just changed up API_PATHS to point to correct endpoints done in [this PR](https://github.com/irakli1603/aws-shop-backend/pull/1)